### PR TITLE
fix: do not publish diagnostics channel event on error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['>=20.18.3', 22.x, 23.x]
+        node-version: ['>=20.18.3', 22.x, 23.x, 24.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/lib/wire.js
+++ b/lib/wire.js
@@ -50,12 +50,8 @@ async function collectBody (stream) {
 
 async function onInject (interceptor, port, id, resolve, injectOpts, error, res) {
   if (error) {
-    channelFinish.publish({
-      request: injectOpts,
-      response: res,
-      server: interceptor[kServer]
-    })
-
+    // Do not emit a channelFinish here because it's not part of Node.js
+    // behavior.
     interceptor[kHooks].fireOnServerError(injectOpts, res, error)
     port.postMessage({ type: MESSAGE_RESPONSE, id, error })
 

--- a/test/fixtures/worker-diagnostics-channel.js
+++ b/test/fixtures/worker-diagnostics-channel.js
@@ -30,7 +30,7 @@ channelFinish.subscribe((event) => {
   events.finish.push({
     method: event.request.method,
     url: event.request.url,
-    statusCode: event.response?.statusCode,
+    statusCode: event.response.statusCode,
     hasServer: !!event.server
   })
 })
@@ -45,6 +45,12 @@ app.get('/events', (_req, reply) => {
 
 app.get('/error', (_req, reply) => {
   throw new Error('test error')
+})
+
+app.get('/destroy', (_req, reply) => {
+  reply.raw.on('error', () => {})
+  reply.raw.destroy(new Error('test error'))
+  return reply
 })
 
 wire({ server: app, port: parentPort })


### PR DESCRIPTION
## Summary
- Removes the `channelFinish` publication on error in the `onInject` function to align with Node.js behavior
- Adds test coverage for destroy response scenario to ensure proper error handling

## Changes
- Modified `lib/wire.js` to remove diagnostics channel event publication on error
- Added new test case for destroy response in `test/diagnostics-channel.test.js`
- Updated test fixture to handle destroy endpoint

## Test plan
- [x] Added test for destroy response scenario
- [x] Existing tests continue to pass
- [x] Verified no spurious events are emitted on error

🤖 Generated with [Claude Code](https://claude.ai/code)