### PR TITLE
fix: Added mesh convergence acknowledgements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ async function main () {
   console.log(await body.json())
 
   await worker.terminate()
-  interceptor.close()
+  await interceptor.close()
   coordinator.destroy()
 }
 
@@ -297,7 +297,7 @@ const server = createServer({
   metadata: { region: 'eu-west-1' }
 })
 
-server.updateMetadata({ region: 'eu-west-1', disabled: true })
+await server.updateMetadata({ region: 'eu-west-1', disabled: true })
 ```
 
 Interceptor target hooks can use server metadata for routing decisions.
@@ -307,16 +307,16 @@ Interceptor target hooks can use server metadata for routing decisions.
 Servers can be paused, resumed, replaced, and closed:
 
 ```js
-server.pause()
-server.resume()
-server.replaceServer(nextApp)
-server.updateMetadata(nextMetadata)
-server.close().catch(error => {
+await server.pause()
+await server.resume()
+await server.replaceServer(nextApp)
+await server.updateMetadata(nextMetadata)
+await server.close().catch(error => {
   throw error
 })
 ```
 
-Paused servers remain visible in mesh snapshots but are skipped by selection. Closing a server removes it from the mesh immediately, then drains queued and in-flight thread-mode requests.
+Paused servers remain visible in mesh snapshots but are skipped by selection. Lifecycle mutation methods resolve only after all relevant interceptors have installed the resulting mesh. Closing a server waits for leave propagation before starting peer draining, so requests selected using a stale snapshot remain admitted through the dispatch boundary.
 
 Interceptors expose lifecycle and mesh inspection helpers:
 
@@ -325,8 +325,8 @@ interceptor.ready
   .then(() => {
     console.log(interceptor.interceptorId)
     console.log(interceptor.getMesh())
-    interceptor.updateMetadata({ role: 'client' })
-    interceptor.close()
+    await interceptor.updateMetadata({ role: 'client' })
+    await interceptor.close()
   })
   .catch(error => {
     throw error

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -391,7 +391,13 @@ The public errors are:
 ```text
 NoAvailableTargetError  code: UND_TI_NO_AVAILABLE_TARGET
 ConnectTimeoutError     code: UND_TI_CONNECT_TIMEOUT
+TargetChangedError      code: UND_TI_TARGET_CHANGED
 ```
+
+Coordinator protocol validation errors use
+`UND_TI_OPERATION_ID_REQUIRED`. A coordinator restart with unsettled mesh
+operations emits a `UND_TI_PENDING_MESH_OPERATIONS` process warning instead of
+silently discarding those operations.
 
 `connectTimeout` applies to peer creation, normal thread-mode responses,
 Undici upgrade handshakes, and the upgrade-agent handshake path. A value of

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -108,9 +108,11 @@ Creating a coordinator registers it process-wide by `meshId`. A second
 coordinator with the same ID throws. The coordinator installs a process
 `workerMessage` listener and starts with an empty mesh.
 
-Members connect by sending `COORDINATOR_CONNECT` with a transferred port. The
-coordinator validates the role and required identity fields, records the member,
-starts the port, and inserts its initial server or interceptor record.
+Members connect by sending `COORDINATOR_CONNECT` with a transferred port and a
+unique `operationId`. The coordinator validates the role and required identity
+fields, records the member, starts the port, and inserts its initial server or
+interceptor record. The operation completes only after relevant interceptors
+acknowledge the resulting snapshot.
 
 Member port closure removes membership. Server and interceptor removal rebuilds
 the origin index and publishes a new snapshot.
@@ -137,11 +139,13 @@ server, and exposes `ready` for registration completion. A server ID is
 generated when one is not provided.
 
 `pause()` and `resume()` update the advertised state and publish
-`SERVER_UPDATE`. Calls after close and redundant state changes are ignored.
+`SERVER_UPDATE`. Their promises resolve after mesh convergence. Calls after
+close and redundant state changes are ignored.
 
 `replaceServer()` replaces the thread-mode target and republishes its upgrade
 capability. A nullish replacement is ignored for TCP targets and rejected for
-thread targets. `updateMetadata()` republishes metadata.
+thread targets. `updateMetadata()` republishes metadata; both return convergence
+promises.
 
 Upgrade capability is advertised when any of the following is true:
 
@@ -193,6 +197,15 @@ The protocol constants are defined in `src/protocol.ts`.
 | `PAUSE`               | coordinator to server      | Requests server pause.                                             |
 | `RESUME`              | coordinator to server      | Requests server resume.                                            |
 | `CLOSE`               | coordinator to server      | Requests server shutdown.                                          |
+
+Mesh mutations carry a unique `operationId`. The coordinator snapshots the
+current interceptor ports when publishing `MESH { operationId, ...mesh }` and
+tracks acknowledgements independently for each operation. Interceptors install
+the snapshot before sending `MESH_ACK { operationId }`. The coordinator replies
+to the mutation initiator with `MESH_APPLIED { operationId }` after every
+snapshot recipient acknowledges, or with `OPERATION_ERROR { operationId, error }`
+when the mutation fails. An interceptor joining later is not added to an
+existing operation, and disconnected recipients are removed from pending sets.
 
 ### Peer messages
 
@@ -271,9 +284,9 @@ message `id` remains the request identity.
 
 When a server starts closing:
 
-1. It immediately marks itself closed and changes its advertised state.
-2. It sends `SERVER_LEAVE` so new target selection stops after mesh propagation.
-3. It keeps the coordinator port open.
+1. It sends `SERVER_LEAVE` while remaining operational.
+2. It waits for `MESH_APPLIED` so stale interceptors have converged.
+3. It marks itself closed and keeps the coordinator port open.
 4. It sends `PEER_DRAIN` to every connected peer.
 5. The interceptor marks that peer as draining and replies with its current
    `lastDispatchIndex`.
@@ -301,9 +314,10 @@ acknowledgement protocol.
 `Server.close()` is idempotent and concurrent callers receive the same promise.
 The close sequence is:
 
-1. Set `#closed`, `#draining`, and state `closed`.
-2. Publish `SERVER_LEAVE` without closing the coordinator port.
-3. Establish peer drain barriers.
+1. Publish `SERVER_LEAVE` without closing the coordinator port.
+2. Wait for mesh convergence while accepting requests from stale snapshots.
+3. Set `#closed`, `#draining`, and state `closed`.
+4. Establish peer drain barriers.
 4. Admit or reject pending upgrades using their dispatch boundaries.
 5. Wait for the request queue and active request handlers.
 6. Wait for established upgrade sockets up to `upgradeDrainTimeout`.

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -33,6 +33,27 @@ interface Member {
   port: MessagePort
 }
 
+interface PendingOperation {
+  initiator?: MessagePort
+  recipients: Set<MessagePort>
+}
+
+const operationMessages: Set<string> = new Set([
+  Message.INTERCEPTOR_UPDATE,
+  Message.INTERCEPTOR_LEAVE,
+  Message.SERVER_UPDATE,
+  Message.SERVER_LEAVE,
+  Message.MESH_ACK
+])
+
+const operationNames: Record<string, string> = {
+  [Message.INTERCEPTOR_UPDATE]: 'Interceptor update',
+  [Message.INTERCEPTOR_LEAVE]: 'Interceptor leave',
+  [Message.SERVER_UPDATE]: 'Server update',
+  [Message.SERVER_LEAVE]: 'Server leave',
+  [Message.MESH_ACK]: 'Mesh acknowledgement'
+}
+
 const coordinators = new Map<string, Coordinator>()
 
 export class Coordinator {
@@ -42,6 +63,8 @@ export class Coordinator {
   #closed: boolean
   #destroyed: boolean
   #boundWorkerMessageListener: (value: unknown) => void
+  #pendingOperations: Map<string, PendingOperation>
+  #internalOperationId: number
 
   constructor (options: CoordinatorOptions) {
     if (coordinators.has(options.meshId)) {
@@ -56,6 +79,8 @@ export class Coordinator {
     this.#closed = false
     this.#destroyed = false
     this.#boundWorkerMessageListener = this.#onWorkerMessage.bind(this)
+    this.#pendingOperations = new Map()
+    this.#internalOperationId = 0
 
     process.on('workerMessage', this.#boundWorkerMessageListener)
   }
@@ -83,6 +108,7 @@ export class Coordinator {
     }
 
     this.#members.clear()
+    this.#pendingOperations.clear()
     this.#mesh = prepareMesh(this.#options.meshId)
   }
 
@@ -93,6 +119,7 @@ export class Coordinator {
 
     this.#closed = false
     this.#members.clear()
+    this.#pendingOperations.clear()
     this.#mesh = prepareMesh(this.#options.meshId)
   }
 
@@ -139,6 +166,12 @@ export class Coordinator {
   }
 
   connectMember (message: CoordinatorConnectMessage): void {
+    if (!message.operationId) {
+      this.#options.onError?.(new Error('Coordinator connect requires an operationId.'))
+      message.port.close()
+      return
+    }
+
     if (this.#closed) {
       message.port.close()
       return
@@ -174,17 +207,24 @@ export class Coordinator {
     message.port.on('close', () => this.#removeMember(member))
     message.port.start()
 
+    const operationId = message.operationId
+
     if (message.role === 'server') {
-      this.#upsertServer(member, {
-        metadata: message.metadata,
-        origin: message.server?.origin,
-        state: message.server?.state,
-        mode: message.server?.mode,
-        address: message.server?.address,
-        capabilities: message.server?.capabilities
-      })
+      this.#upsertServer(
+        member,
+        {
+          metadata: message.metadata,
+          origin: message.server?.origin,
+          state: message.server?.state,
+          mode: message.server?.mode,
+          address: message.server?.address,
+          capabilities: message.server?.capabilities
+        },
+        operationId,
+        message.port
+      )
     } else {
-      this.#upsertInterceptor(member, message.metadata)
+      this.#upsertInterceptor(member, message.metadata, operationId, message.port)
     }
   }
 
@@ -200,29 +240,45 @@ export class Coordinator {
     const message = value as { type?: string; [key: string]: unknown }
 
     try {
+      const operationId = operationMessages.has(message.type ?? '') ? this.#requireOperationId(message) : undefined
+
       switch (message.type) {
         case Message.INTERCEPTOR_UPDATE:
-          this.#upsertInterceptor(member, message.metadata)
+          this.#upsertInterceptor(member, message.metadata, operationId!, member.port)
           break
         case Message.INTERCEPTOR_LEAVE:
-          this.#removeInterceptor(member.id)
+          this.#removeInterceptor(member.id, operationId!, member.port)
           break
         case Message.SERVER_UPDATE:
-          this.#upsertServer(member, message)
+          this.#upsertServer(member, message, operationId!, member.port)
           break
         case Message.SERVER_LEAVE:
-          this.#removeServer(member.id)
+          this.#removeServer(member.id, operationId!, member.port)
           break
         case Message.GET_MESH:
           member.port.postMessage({ type: Message.MESH, mesh: this.#mesh })
           break
+        case Message.MESH_ACK:
+          this.#acknowledge(member.port, operationId!)
+          break
       }
     } catch (error) {
       this.#options.onError?.(error as Error)
+      if (typeof message.operationId === 'string' && message.operationId.length > 0) {
+        member.port.postMessage({ type: Message.OPERATION_ERROR, operationId: message.operationId, error })
+      }
     }
   }
 
-  #upsertInterceptor (member: Member, metadata: unknown): void {
+  #requireOperationId (message: { type?: string; operationId?: unknown }): string {
+    if (typeof message.operationId !== 'string' || message.operationId.length === 0) {
+      throw new Error(`${operationNames[message.type ?? ''] ?? 'Mesh operation'} requires an operationId.`)
+    }
+
+    return message.operationId
+  }
+
+  #upsertInterceptor (member: Member, metadata: unknown, operationId: string, initiator?: MessagePort): void {
     const interceptor: MeshInterceptor = {
       interceptorId: member.id,
       threadId: member.threadId,
@@ -237,10 +293,10 @@ export class Coordinator {
       this.#options.onInterceptorAvailable?.(interceptor)
     }
 
-    this.#publishMesh()
+    this.#publishMesh(operationId, initiator)
   }
 
-  #upsertServer (member: Member, message: Record<string, unknown>): void {
+  #upsertServer (member: Member, message: Record<string, unknown>, operationId: string, initiator?: MessagePort): void {
     const previous = this.#mesh.servers[member.id]
     /* c8 ignore next - else */
     const serverState = (message.state ?? previous?.state ?? 'available') as State
@@ -294,20 +350,25 @@ export class Coordinator {
     }
 
     this.#rebuildOrigins()
-    this.#publishMesh()
+    this.#publishMesh(operationId, initiator)
   }
 
   #removeMember (member: Member): void {
     this.#members.delete(member.port)
 
+    for (const [operationId, operation] of this.#pendingOperations) {
+      operation.recipients.delete(member.port)
+      this.#completeIfApplied(operationId)
+    }
+
     if (member.role === 'interceptor') {
-      this.#removeInterceptor(member.id)
+      this.#removeInterceptor(member.id, this.#nextInternalOperationId())
     } else {
-      this.#removeServer(member.id)
+      this.#removeServer(member.id, this.#nextInternalOperationId())
     }
   }
 
-  #removeInterceptor (interceptorId: string): void {
+  #removeInterceptor (interceptorId: string, operationId: string, initiator?: MessagePort): void {
     const interceptor = this.#mesh.interceptors[interceptorId]
 
     if (!interceptor) {
@@ -316,10 +377,10 @@ export class Coordinator {
 
     delete this.#mesh.interceptors[interceptorId]
     this.#options.onInterceptorClosed?.(interceptor)
-    this.#publishMesh()
+    this.#publishMesh(operationId, initiator, this.getMember('interceptor', interceptorId)?.port)
   }
 
-  #removeServer (serverId: string): void {
+  #removeServer (serverId: string, operationId: string, initiator?: MessagePort): void {
     const server = this.#mesh.servers[serverId]
 
     if (!server) {
@@ -329,7 +390,7 @@ export class Coordinator {
     delete this.#mesh.servers[serverId]
     this.#options.onServerClosed?.({ ...server, state: 'closed' })
     this.#rebuildOrigins()
-    this.#publishMesh()
+    this.#publishMesh(operationId, initiator)
   }
 
   #rebuildOrigins (): void {
@@ -341,13 +402,26 @@ export class Coordinator {
     }
   }
 
-  #publishMesh (): void {
+  #publishMesh (operationId: string, initiator?: MessagePort, excluded?: MessagePort): void {
     this.#mesh.version++
 
-    const message = { type: Message.MESH, mesh: this.#mesh }
+    const recipients = new Set<MessagePort>()
+    for (const member of this.#members.values()) {
+      if (member.role === 'interceptor' && member.port !== excluded) {
+        recipients.add(member.port)
+      }
+    }
+
+    this.#pendingOperations.set(operationId, { initiator, recipients })
+    const message = { type: Message.MESH, operationId, mesh: this.#mesh }
 
     for (const member of this.#members.values()) {
-      member.port.postMessage(message)
+      try {
+        member.port.postMessage(message)
+      } catch (error) {
+        recipients.delete(member.port)
+        this.#options.onError?.(error as Error)
+      }
     }
 
     const mesh = structuredClone(this.#mesh)
@@ -358,6 +432,44 @@ export class Coordinator {
 
     /* c8 ignore next - else */
     this.#options.onMesh?.(mesh)
+
+    this.#completeIfApplied(operationId)
+  }
+
+  #acknowledge (port: MessagePort, operationId: string): void {
+    const operation = this.#pendingOperations.get(operationId)
+    if (!operation) {
+      return
+    }
+
+    operation.recipients.delete(port)
+    this.#completeIfApplied(operationId)
+  }
+
+  #completeIfApplied (operationId: string): void {
+    const operation = this.#pendingOperations.get(operationId)
+    if (!operation || operation.recipients.size > 0) {
+      return
+    }
+
+    this.#pendingOperations.delete(operationId)
+    if (operation.initiator) {
+      setImmediate(() => {
+        try {
+          if (this.#members.get(operation.initiator!)?.role === 'server') {
+            operation.initiator?.postMessage({ type: Message.MESH, mesh: this.#mesh })
+          }
+          operation.initiator?.postMessage({ type: Message.MESH_APPLIED, operationId })
+        } catch (error) {
+          this.#options.onError?.(error as Error)
+        }
+      }).unref()
+    }
+  }
+
+  #nextInternalOperationId (): string {
+    this.#internalOperationId++
+    return `internal-${this.#internalOperationId}`
   }
 
   #onWorkerMessage (value: unknown) {

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -1,4 +1,5 @@
 import type { MessagePort } from 'node:worker_threads'
+import process from 'node:process'
 
 import { channels } from './diagnostics.ts'
 import {
@@ -119,6 +120,12 @@ export class Coordinator {
 
     this.#closed = false
     this.#members.clear()
+    if (this.#pendingOperations.size > 0) {
+      process.emitWarning(
+        `Restarting coordinator ${this.#options.meshId} with ${this.#pendingOperations.size} unsettled mesh operation(s).`,
+        { code: 'UND_TI_PENDING_MESH_OPERATIONS' }
+      )
+    }
     this.#pendingOperations.clear()
     this.#mesh = prepareMesh(this.#options.meshId)
   }
@@ -167,7 +174,7 @@ export class Coordinator {
 
   connectMember (message: CoordinatorConnectMessage): void {
     if (!message.operationId) {
-      this.#options.onError?.(new Error('Coordinator connect requires an operationId.'))
+      this.#options.onError?.(this.#operationIdError('Coordinator connect'))
       message.port.close()
       return
     }
@@ -265,17 +272,28 @@ export class Coordinator {
     } catch (error) {
       this.#options.onError?.(error as Error)
       if (typeof message.operationId === 'string' && message.operationId.length > 0) {
-        member.port.postMessage({ type: Message.OPERATION_ERROR, operationId: message.operationId, error })
+        member.port.postMessage({
+          type: Message.OPERATION_ERROR,
+          operationId: message.operationId,
+          error,
+          code: (error as Error & { code?: string }).code
+        })
       }
     }
   }
 
   #requireOperationId (message: { type?: string; operationId?: unknown }): string {
     if (typeof message.operationId !== 'string' || message.operationId.length === 0) {
-      throw new Error(`${operationNames[message.type ?? ''] ?? 'Mesh operation'} requires an operationId.`)
+      throw this.#operationIdError(operationNames[message.type ?? ''] ?? 'Mesh operation')
     }
 
     return message.operationId
+  }
+
+  #operationIdError (operation: string): Error & { code: string } {
+    const error = new Error(`${operation} requires an operationId.`) as Error & { code: string }
+    error.code = 'UND_TI_OPERATION_ID_REQUIRED'
+    return error
   }
 
   #upsertInterceptor (member: Member, metadata: unknown, operationId: string, initiator?: MessagePort): void {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,3 +17,13 @@ export class ConnectTimeoutError extends Error {
     this.code = 'UND_TI_CONNECT_TIMEOUT'
   }
 }
+
+export class TargetChangedError extends Error {
+  code: string
+
+  constructor (message = 'Mesh target changed during dispatch.') {
+    super(message)
+    this.name = 'TargetChangedError'
+    this.code = 'UND_TI_TARGET_CHANGED'
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { Coordinator, createCoordinator, type CoordinatorOptions } from './coordinator.ts'
-export { ConnectTimeoutError, NoAvailableTargetError } from './errors.ts'
+export { ConnectTimeoutError, NoAvailableTargetError, TargetChangedError } from './errors.ts'
 export { createInterceptor, Interceptor, type InterceptorFunction, type InterceptorOptions } from './interceptor.ts'
 export type {
   Mesh,

--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -32,7 +32,8 @@ import {
   type PeerConnectMessage,
   type RequestMessage,
   type ResponseMessage,
-  type UpgradeMessage
+  type UpgradeMessage,
+  type OperationErrorMessage
 } from './protocol.ts'
 import {
   createId,
@@ -72,8 +73,8 @@ interface InterceptorHooks {
 export interface InterceptorFunction extends Dispatcher.DispatcherComposeInterceptor {
   interceptorId: string
   ready: Promise<void>
-  close: () => void
-  updateMetadata: (metadata: unknown) => void
+  close: () => Promise<void>
+  updateMetadata: (metadata: unknown) => Promise<void>
   getMesh: () => Mesh | null
   createUpgradeAgent: () => HttpAgent
 }
@@ -96,6 +97,7 @@ interface PendingRequest {
 }
 
 interface Peer {
+  serverId: string
   port: MessagePort
   pending: Map<string, PendingRequest>
   tunnels: Set<MessagePortDuplex>
@@ -201,6 +203,9 @@ export class Interceptor {
   #peers: Map<string, Peer>
   #requestId: () => string
   #closed: boolean
+  #operations: Map<string, { resolve: () => void; reject: (error: Error) => void }>
+  #closePromise: Promise<void> | null
+  #controlPortClosed: boolean
 
   constructor (options: InterceptorOptions) {
     this.#options = options
@@ -219,16 +224,27 @@ export class Interceptor {
     this.#peers = new Map()
     this.#requestId = hyperid()
     this.#closed = false
+    this.#operations = new Map()
+    this.#closePromise = null
+    this.#controlPortClosed = false
 
     const channel = new MessageChannel()
     this.#port = channel.port1
     this.#port.on('message', value => this.#onCoordinatorMessage(value))
+    this.#port.on('close', () => {
+      this.#controlPortClosed = true
+      for (const operation of this.#operations.values()) {
+        operation.resolve()
+      }
+      this.#operations.clear()
+    })
     this.#port.start()
 
     const coordinatorThreadId = options.coordinatorThreadId ?? 0
     const bootstrapTimeout = options.bootstrapTimeout ?? 100
     const connectMessage: CoordinatorConnectMessage = {
       type: Message.COORDINATOR_CONNECT,
+      operationId: '',
       meshId: options.meshId,
       role: 'interceptor' as const,
       threadId,
@@ -239,7 +255,13 @@ export class Interceptor {
       }
     }
 
-    this.ready = sendThreadMessage(coordinatorThreadId, connectMessage, [channel.port2], bootstrapTimeout)
+    const operation = this.#createOperation()
+    connectMessage.operationId = operation.operationId
+    const transport = sendThreadMessage(coordinatorThreadId, connectMessage, [channel.port2], bootstrapTimeout)
+    this.ready =
+      coordinatorThreadId === threadId && process.listenerCount('workerMessage') === 0
+        ? transport
+        : transport.then(() => operation.promise)
     this.ready.catch(error => runHooks(this.#hooks.onError, null, null, {}, error as Error))
   }
 
@@ -261,32 +283,45 @@ export class Interceptor {
     return this.#mesh
   }
 
-  close (): void {
+  close (): Promise<void> {
     if (this.#closed) {
-      return
+      return this.#closePromise ?? Promise.resolve()
     }
 
     this.#closed = true
+    const operation = this.#createOperation()
     this.#port.postMessage({
       type: Message.INTERCEPTOR_LEAVE,
+      operationId: operation.operationId,
       meshId: this.#options.meshId,
       interceptorId: this.interceptorId
     })
-    this.#port.close()
 
-    for (const peer of this.#peers.values()) {
-      peer.port.postMessage({ type: Message.PEER_DISCONNECT })
-      peer.port.close()
-    }
+    const convergence =
+      this.#controlPortClosed || process.listenerCount('workerMessage') === 0
+        ? Promise.race([operation.promise, new Promise<void>(resolve => setTimeout(resolve, this.#options.bootstrapTimeout ?? 100))])
+        : operation.promise
+    this.#closePromise = convergence.then(() => {
+      this.#port.close()
+
+      for (const peer of this.#peers.values()) {
+        peer.port.postMessage({ type: Message.PEER_DISCONNECT })
+        peer.port.close()
+      }
+    })
+    return this.#closePromise
   }
 
-  updateMetadata (metadata: unknown): void {
+  updateMetadata (metadata: unknown): Promise<void> {
+    const operation = this.#createOperation()
     this.#port.postMessage({
       type: Message.INTERCEPTOR_UPDATE,
+      operationId: operation.operationId,
       meshId: this.#options.meshId,
       interceptorId: this.interceptorId,
       metadata
     })
+    return operation.promise
   }
 
   dispatch (dispatch: Dispatch, opts: DispatchOptions, handler: DispatchHandler): boolean {
@@ -324,8 +359,27 @@ export class Interceptor {
     }
 
     if (server.mode === 'tcp') {
+      const current = this.#currentServer(server, key, Boolean(opts.upgrade))
+      if (!current) {
+        const replacement = this.#selectServer(key, this.#mesh?.origins[key]?.servers ?? [], request, context, Boolean(opts.upgrade))
+        if (!replacement) {
+          throw new NoAvailableTargetError(key)
+        }
+        if (replacement.mode === 'thread') {
+          this.#dispatchViaMessagePort(replacement, url, request, context, handler).catch(error => {
+            this.#publishRequestError(request, context, error as Error)
+            runHooks(this.#hooks.onError, request, null, context, error as Error)
+            handler.onResponseError?.(null as any, error as Error)
+          })
+          return true
+        }
+        return dispatch(
+          { ...request, origin: replacement.address } as DispatchOptions,
+          new HookHandler(handler, this.#hooks, request, context)
+        )
+      }
       return dispatch(
-        { ...request, origin: server.address } as DispatchOptions,
+        { ...request, origin: (current as Extract<MeshServer, { mode: 'tcp' }>).address } as DispatchOptions,
         new HookHandler(handler, this.#hooks, request, context)
       )
     }
@@ -354,7 +408,18 @@ export class Interceptor {
   }
 
   #onCoordinatorMessage (value: unknown): void {
-    const message = value as { type?: string; mesh?: Mesh }
+    const message = value as { type?: string; mesh?: Mesh; operationId?: string }
+
+    if (message.type === Message.MESH_APPLIED) {
+      this.#operations.get(message.operationId as string)?.resolve()
+      return
+    }
+
+    if (message.type === Message.OPERATION_ERROR) {
+      const operation = message as unknown as OperationErrorMessage
+      this.#operations.get(operation.operationId)?.reject(operation.error)
+      return
+    }
 
     /* c8 ignore next 3 - hard to test */
     if (message.type !== Message.MESH || !message.mesh) {
@@ -362,12 +427,45 @@ export class Interceptor {
     }
 
     /* c8 ignore next 3 - hard to test */
-    if (this.#mesh && message.mesh.version <= this.#mesh.version) {
+    if (!this.#mesh || message.mesh.version > this.#mesh.version) {
+      this.#retireStalePeers(this.#mesh, message.mesh)
+      this.#mesh = message.mesh
+      this.#cursors.clear()
+    }
+
+    if (message.operationId) {
+      this.#port.postMessage({ type: Message.MESH_ACK, operationId: message.operationId })
+    }
+  }
+
+  #createOperation (): { operationId: string; promise: Promise<void> } {
+    const operationId = createId()
+    const { promise, resolve, reject } = Promise.withResolvers<void>()
+    this.#operations.set(operationId, { resolve, reject })
+    promise.finally(() => this.#operations.delete(operationId)).catch(() => {})
+    return { operationId, promise }
+  }
+
+  #retireStalePeers (previous: Mesh | null, next: Mesh): void {
+    if (!previous) {
       return
     }
 
-    this.#mesh = message.mesh
-    this.#cursors.clear()
+    for (const [key, peer] of this.#peers) {
+      const before = previous.servers[peer.serverId]
+      const after = next.servers[peer.serverId]
+      const changed =
+        !after ||
+        !before ||
+        before.mode !== after.mode ||
+        (before.mode === 'thread' && after.mode === 'thread' && before.threadId !== after.threadId) ||
+        (before.mode === 'tcp' && after.mode === 'tcp' && before.address !== after.address)
+
+      if (changed) {
+        this.#peers.delete(key)
+        peer.draining = true
+      }
+    }
   }
 
   #selectServer (
@@ -404,6 +502,17 @@ export class Interceptor {
     handler: DispatchHandler
   ): Promise<void> {
     const peer = await this.#ensurePeerMessagePort(server)
+    const current = this.#currentServer(server, server.origin)
+    if (!current || current.mode !== 'thread') {
+      const replacement = this.#selectServer(server.origin, this.#mesh?.origins[server.origin]?.servers ?? [], request, context)
+      if (!replacement) {
+        throw new NoAvailableTargetError(server.origin)
+      }
+      if (replacement.mode === 'tcp') {
+        throw new Error('mesh target changed from thread to tcp during dispatch')
+      }
+      return this.#dispatchViaMessagePort(replacement, url, request, context, handler)
+    }
     const id = this.#requestId()
     const { promise: responsePromise, resolve, reject } = Promise.withResolvers<void>()
 
@@ -492,7 +601,24 @@ export class Interceptor {
     context: Record<PropertyKey, unknown>,
     handler: DispatchHandler
   ): Promise<void> {
+    const selected = this.#currentServer(server, server.origin, true)
+    if (!selected || selected.mode !== 'thread') {
+      const replacement = this.#selectServer(server.origin, this.#mesh?.origins[server.origin]?.servers ?? [], request, context, true)
+      if (!replacement || replacement.mode !== 'thread') {
+        throw new NoAvailableTargetError(server.origin)
+      }
+      return this.#dispatchUpgradeViaMessagePort(replacement, url, request, context, handler)
+    }
+
     const peer = await this.#ensurePeerMessagePort(server)
+    const current = this.#currentServer(server, server.origin, true)
+    if (!current || current.mode !== 'thread') {
+      const replacement = this.#selectServer(server.origin, this.#mesh?.origins[server.origin]?.servers ?? [], request, context, true)
+      if (!replacement || replacement.mode !== 'thread') {
+        throw new NoAvailableTargetError(server.origin)
+      }
+      return this.#dispatchUpgradeViaMessagePort(replacement, url, request, context, handler)
+    }
     const id = this.#requestId()
     const channel = new MessageChannel()
     const { promise, resolve, reject } = Promise.withResolvers<void>()
@@ -1020,6 +1146,7 @@ export class Interceptor {
     }
 
     const peer: Peer = {
+      serverId,
       port: channel.port1,
       pending: new Map(),
       tunnels: new Set(),
@@ -1033,6 +1160,9 @@ export class Interceptor {
     channel.port1.on('message', value => this.#onPeerMessage(peer, value))
     channel.port1.on('close', () => {
       peer.closed = true
+      if (this.#peers.get(key) === peer) {
+        this.#peers.delete(key)
+      }
 
       if (channels.peerDisconnect.hasSubscribers) {
         channels.peerDisconnect.publish(diagnostics)
@@ -1247,6 +1377,31 @@ export class Interceptor {
     }
 
     return true
+  }
+
+  #currentServer (
+    selected: MeshServer,
+    origin: string,
+    needsUpgrade = false
+  ): MeshServer | null {
+    const current = this.#mesh?.servers[selected.serverId]
+    if (!current || current.state !== 'available' || current.origin !== origin || current.mode !== selected.mode) {
+      return null
+    }
+
+    if (current.mode === 'thread' && selected.mode === 'thread' && current.threadId !== selected.threadId) {
+      return null
+    }
+
+    if (current.mode === 'tcp' && selected.mode === 'tcp' && current.address !== selected.address) {
+      return null
+    }
+
+    if (needsUpgrade && current.capabilities?.upgrade === false) {
+      return null
+    }
+
+    return current
   }
 
   #publishRequestError (request: any, context: Record<PropertyKey, unknown>, error: Error): void {

--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -14,7 +14,7 @@ import {
   publishRequestHeaders,
   type PeerDiagnosticsPayload
 } from './diagnostics.ts'
-import { ConnectTimeoutError, NoAvailableTargetError } from './errors.ts'
+import { ConnectTimeoutError, NoAvailableTargetError, TargetChangedError } from './errors.ts'
 import { FakeSocket } from './fake-socket.ts'
 import {
   HttpRequestHeadParser,
@@ -297,10 +297,9 @@ export class Interceptor {
       interceptorId: this.interceptorId
     })
 
-    const convergence =
-      this.#controlPortClosed || process.listenerCount('workerMessage') === 0
-        ? Promise.race([operation.promise, new Promise<void>(resolve => setTimeout(resolve, this.#options.bootstrapTimeout ?? 100))])
-        : operation.promise
+    const convergence = this.#controlPortClosed || process.listenerCount('workerMessage') === 0
+      ? Promise.resolve()
+      : operation.promise
     this.#closePromise = convergence.then(() => {
       this.#port.close()
 
@@ -417,7 +416,11 @@ export class Interceptor {
 
     if (message.type === Message.OPERATION_ERROR) {
       const operation = message as unknown as OperationErrorMessage
-      this.#operations.get(operation.operationId)?.reject(operation.error)
+      const error = operation.error as Error & { code?: string }
+      if (operation.code) {
+        error.code = operation.code
+      }
+      this.#operations.get(operation.operationId)?.reject(error)
       return
     }
 
@@ -509,7 +512,7 @@ export class Interceptor {
         throw new NoAvailableTargetError(server.origin)
       }
       if (replacement.mode === 'tcp') {
-        throw new Error('mesh target changed from thread to tcp during dispatch')
+        throw new TargetChangedError('Mesh target changed from thread to TCP during dispatch.')
       }
       return this.#dispatchViaMessagePort(replacement, url, request, context, handler)
     }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -10,6 +10,9 @@ export const Message = {
   SERVER_LEAVE: 'undici-thread-interceptor.server.leave',
   GET_MESH: 'undici-thread-interceptor.mesh.get',
   MESH: 'undici-thread-interceptor.mesh',
+  MESH_ACK: 'undici-thread-interceptor.mesh.ack',
+  MESH_APPLIED: 'undici-thread-interceptor.mesh.applied',
+  OPERATION_ERROR: 'undici-thread-interceptor.operation.error',
   PAUSE: 'undici-thread-interceptor.pause',
   RESUME: 'undici-thread-interceptor.resume',
   CLOSE: 'undici-thread-interceptor.close',
@@ -76,6 +79,7 @@ export interface Mesh {
 
 export interface CoordinatorConnectMessage {
   type: typeof Message.COORDINATOR_CONNECT
+  operationId: string
   meshId: string
   role: Role
   metadata?: unknown
@@ -92,6 +96,28 @@ export interface CoordinatorConnectMessage {
   }
   threadId: number
   port: MessagePort
+}
+
+export interface MeshMessage {
+  type: typeof Message.MESH
+  operationId?: string
+  mesh: Mesh
+}
+
+export interface MeshAckMessage {
+  type: typeof Message.MESH_ACK
+  operationId: string
+}
+
+export interface MeshAppliedMessage {
+  type: typeof Message.MESH_APPLIED
+  operationId: string
+}
+
+export interface OperationErrorMessage {
+  type: typeof Message.OPERATION_ERROR
+  operationId: string
+  error: Error
 }
 
 export interface PeerConnectMessage {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -118,6 +118,7 @@ export interface OperationErrorMessage {
   type: typeof Message.OPERATION_ERROR
   operationId: string
   error: Error
+  code?: string
 }
 
 export interface PeerConnectMessage {

--- a/src/server.ts
+++ b/src/server.ts
@@ -198,10 +198,9 @@ export class Server {
       serverId: this.serverId
     })
 
-    const convergence =
-      this.#controlPortClosed || process.listenerCount('workerMessage') <= 1
-        ? Promise.race([operation.promise, new Promise<void>(resolve => setTimeout(resolve, this.#options.bootstrapTimeout ?? 100))])
-        : operation.promise
+    const convergence = this.#controlPortClosed || process.listenerCount('workerMessage') <= 1
+      ? Promise.resolve()
+      : operation.promise
     this.#closePromise = convergence.then(() => {
       this.#closed = true
       this.#draining = true

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,8 @@ import {
   type RequestMessage,
   type ResponseMessage,
   type State,
-  type UpgradeMessage
+  type UpgradeMessage,
+  type OperationErrorMessage
 } from './protocol.ts'
 import { createRequestQueue, type RequestQueue } from './request-queue.ts'
 import {
@@ -86,6 +87,8 @@ export class Server {
   #draining: boolean
   #closePromise: Promise<void> | null
   #boundWorkerMessageListener: (value: unknown) => void
+  #operations: Map<string, { resolve: () => void; reject: (error: Error) => void }>
+  #controlPortClosed: boolean
 
   constructor (options: ServerOptions) {
     if (options.domain.includes('://') || /^[a-z][a-z0-9+.-]*:/i.test(options.domain)) {
@@ -117,10 +120,19 @@ export class Server {
     this.#draining = false
     this.#closePromise = null
     this.#boundWorkerMessageListener = this.#onWorkerMessage.bind(this)
+    this.#operations = new Map()
+    this.#controlPortClosed = false
 
     const channel = new MessageChannel()
     this.#port = channel.port1
     this.#port.on('message', value => this.#onCoordinatorMessage(value))
+    this.#port.on('close', () => {
+      this.#controlPortClosed = true
+      for (const operation of this.#operations.values()) {
+        operation.resolve()
+      }
+      this.#operations.clear()
+    })
     this.#port.start()
 
     process.on('workerMessage', this.#boundWorkerMessageListener)
@@ -129,6 +141,7 @@ export class Server {
     const bootstrapTimeout = options.bootstrapTimeout ?? 100
     const connectMessage: CoordinatorConnectMessage = {
       type: Message.COORDINATOR_CONNECT,
+      operationId: '',
       meshId: options.meshId,
       role: 'server' as const,
       threadId,
@@ -144,26 +157,32 @@ export class Server {
       }
     }
 
-    this.ready = sendThreadMessage(coordinatorThreadId, connectMessage, [channel.port2], bootstrapTimeout)
+    const operation = this.#createOperation()
+    connectMessage.operationId = operation.operationId
+    const transport = sendThreadMessage(coordinatorThreadId, connectMessage, [channel.port2], bootstrapTimeout)
+    this.ready =
+      coordinatorThreadId === threadId && process.listenerCount('workerMessage') === 0
+        ? transport
+        : transport.then(() => operation.promise)
     this.ready.catch(error => runHooks(this.#hooks.onError, null, null, error as Error))
   }
 
-  pause (): void {
+  pause (): Promise<void> {
     if (this.#closed || this.#state === 'paused') {
-      return
+      return Promise.resolve()
     }
 
     this.#state = 'paused'
-    this.#update()
+    return this.#update()
   }
 
-  resume (): void {
+  resume (): Promise<void> {
     if (this.#closed || this.#state === 'available') {
-      return
+      return Promise.resolve()
     }
 
     this.#state = 'available'
-    this.#update()
+    return this.#update()
   }
 
   close (): Promise<void> {
@@ -171,31 +190,43 @@ export class Server {
       return this.#closePromise
     }
 
-    this.#closed = true
-    this.#draining = true
-    this.#state = 'closed'
-    this.#port.postMessage({ type: Message.SERVER_LEAVE, meshId: this.#options.meshId, serverId: this.serverId })
+    const operation = this.#createOperation()
+    this.#port.postMessage({
+      type: Message.SERVER_LEAVE,
+      operationId: operation.operationId,
+      meshId: this.#options.meshId,
+      serverId: this.serverId
+    })
 
-    this.#closePromise = this.#drainAndClose()
+    const convergence =
+      this.#controlPortClosed || process.listenerCount('workerMessage') <= 1
+        ? Promise.race([operation.promise, new Promise<void>(resolve => setTimeout(resolve, this.#options.bootstrapTimeout ?? 100))])
+        : operation.promise
+    this.#closePromise = convergence.then(() => {
+      this.#closed = true
+      this.#draining = true
+      this.#state = 'closed'
+      return this.#drainAndClose()
+    })
     return this.#closePromise
   }
 
-  replaceServer (server: any): void {
+  replaceServer (server: any): Promise<void> {
     if (server == null) {
       if (this.#getMode() === 'tcp') {
-        return
+        return Promise.resolve()
       }
 
       throw new Error('server argument is required')
     }
 
     this.#server = server
-    this.#update()
+    return this.#update()
   }
 
-  updateMetadata (metadata: unknown): void {
+  updateMetadata (metadata: unknown): Promise<void> {
     this.#metadata = metadata
-    this.#update()
+    return this.#update()
   }
 
   addPeer (port: MessagePort, interceptorId = 'unknown'): void {
@@ -243,9 +274,11 @@ export class Server {
     }
   }
 
-  #update (): void {
+  #update (): Promise<void> {
+    const operation = this.#createOperation()
     this.#port.postMessage({
       type: Message.SERVER_UPDATE,
+      operationId: operation.operationId,
       meshId: this.#options.meshId,
       serverId: this.serverId,
       origin: this.#origin,
@@ -255,6 +288,15 @@ export class Server {
       address: this.#getAddress(),
       capabilities: this.#getCapabilities()
     })
+    return operation.promise
+  }
+
+  #createOperation (): { operationId: string; promise: Promise<void> } {
+    const operationId = createId()
+    const { promise, resolve, reject } = Promise.withResolvers<void>()
+    this.#operations.set(operationId, { resolve, reject })
+    promise.finally(() => this.#operations.delete(operationId)).catch(() => {})
+    return { operationId, promise }
   }
 
   #getCapabilities (): { upgrade: boolean } {
@@ -351,6 +393,16 @@ export class Server {
       case Message.CLOSE:
         this.close().catch(error => runHooks(this.#hooks.onError, null, null, error as Error))
         break
+      case Message.MESH_APPLIED: {
+        const operation = this.#operations.get((message as { operationId: string }).operationId)
+        operation?.resolve()
+        break
+      }
+      case Message.OPERATION_ERROR: {
+        const operation = this.#operations.get((message as OperationErrorMessage).operationId)
+        operation?.reject((message as OperationErrorMessage).error)
+        break
+      }
     }
   }
 

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -638,8 +638,8 @@ test('coordinator accepts interceptor updates and ignores invalid worker message
 
 test('coordinator rejects mesh mutations without operation IDs', async t => {
   const id = directMeshId('missing-operation-id')
-  const errors: string[] = []
-  const coordinator = createCoordinator({ meshId: id, onError: error => errors.push(error.message) })
+  const errors: Array<{ message: string; code?: string }> = []
+  const coordinator = createCoordinator({ meshId: id, onError: error => errors.push({ message: error.message, code: (error as Error & { code?: string }).code }) })
   t.after(() => coordinator.destroy())
 
   const channel = new MessageChannel()
@@ -663,7 +663,7 @@ test('coordinator rejects mesh mutations without operation IDs', async t => {
   await sleep(10)
 
   strictEqual(coordinator.getMesh().servers['server-1'].state, 'available')
-  deepStrictEqual(errors, ['Server update requires an operationId.'])
+  deepStrictEqual(errors, [{ message: 'Server update requires an operationId.', code: 'UND_TI_OPERATION_ID_REQUIRED' }])
   channel.port2.close()
 })
 

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -33,6 +33,7 @@ function connectServer (
   const channel = new MessageChannel()
   coordinator.connectMember({
     type: Message.COORDINATOR_CONNECT,
+    operationId: `connect-${id}`,
     meshId: coordinator.getMesh().meshId,
     role: 'server',
     threadId,
@@ -122,7 +123,7 @@ test('closes and re-adds a server for the same origin', async t => {
   await createWorkerServer(t, {
     meshId,
     coordinatorThreadId,
-    serverId: 'server-2',
+    serverId: 'server:2',
     domain: 'read.local',
     message: 'second'
   })
@@ -356,14 +357,14 @@ test('keeps routing when one worker exits and another serves the same origin', a
   const worker = await createWorkerServer(t, {
     meshId,
     coordinatorThreadId,
-    serverId: 'server-1',
+    serverId: 'server:1',
     domain: 'survive.local',
     message: 'gone'
   })
   await createWorkerServer(t, {
     meshId,
     coordinatorThreadId,
-    serverId: 'server-2',
+    serverId: 'server:2',
     domain: 'survive.local',
     message: 'survived'
   })
@@ -560,13 +561,13 @@ test('coordinator handles member validation and lifecycle edge messages', async 
     const [{ mesh }] = (await once(remote, 'message')) as Array<{ mesh: { meshId: string } }>
     strictEqual(mesh.meshId, id)
 
-    remote.postMessage({ type: Message.SERVER_UPDATE, state: 'paused' })
-    remote.postMessage({ type: Message.SERVER_UPDATE, state: 'available' })
-    remote.postMessage({ type: Message.SERVER_UPDATE, state: 'unavailable' })
-    remote.postMessage({ type: Message.SERVER_UPDATE, state: 'closed' })
-    remote.postMessage({ type: Message.SERVER_UPDATE, state: 'available' })
-    remote.postMessage({ type: Message.SERVER_UPDATE, state: 'unavailable' })
-    remote.postMessage({ type: Message.SERVER_UPDATE, state: 'unavailable' })
+    remote.postMessage({ type: Message.SERVER_UPDATE, operationId: 'server-update-1', state: 'paused' })
+    remote.postMessage({ type: Message.SERVER_UPDATE, operationId: 'server-update-2', state: 'available' })
+    remote.postMessage({ type: Message.SERVER_UPDATE, operationId: 'server-update-3', state: 'unavailable' })
+    remote.postMessage({ type: Message.SERVER_UPDATE, operationId: 'server-update-4', state: 'closed' })
+    remote.postMessage({ type: Message.SERVER_UPDATE, operationId: 'server-update-5', state: 'available' })
+    remote.postMessage({ type: Message.SERVER_UPDATE, operationId: 'server-update-6', state: 'unavailable' })
+    remote.postMessage({ type: Message.SERVER_UPDATE, operationId: 'server-update-7', state: 'unavailable' })
     await sleep(20)
 
     deepStrictEqual(events, [
@@ -579,14 +580,20 @@ test('coordinator handles member validation and lifecycle edge messages', async 
       'unavailable:server-1',
       'updated:server-1'
     ])
-    deepStrictEqual(errors, ['update failed'])
+    deepStrictEqual(errors, [
+      'Coordinator connect requires an operationId.',
+      'Coordinator connect requires an operationId.',
+      'Coordinator connect requires an operationId.',
+      'Coordinator connect requires an operationId.',
+      'update failed'
+    ])
 
     coordinator.close('missing')
     coordinator.close('server-1')
     coordinator.pause('missing')
     coordinator.resume('missing')
-    remote.postMessage({ type: Message.SERVER_LEAVE })
-    remote.postMessage({ type: Message.SERVER_LEAVE })
+    remote.postMessage({ type: Message.SERVER_LEAVE, operationId: 'server-leave-1' })
+    remote.postMessage({ type: Message.SERVER_LEAVE, operationId: 'server-leave-2' })
     await sleep(20)
     ok(events.includes('closed:server-1'))
     remote.close()
@@ -606,6 +613,7 @@ test('coordinator accepts interceptor updates and ignores invalid worker message
     const channel = new MessageChannel()
     process.emit('workerMessage', {
       type: Message.COORDINATOR_CONNECT,
+      operationId: 'interceptor-connect',
       meshId: id,
       role: 'interceptor',
       threadId,
@@ -614,9 +622,9 @@ test('coordinator accepts interceptor updates and ignores invalid worker message
     } as CoordinatorConnectMessage)
     await once(channel.port2, 'message')
 
-    channel.port2.postMessage({ type: Message.INTERCEPTOR_UPDATE, metadata: { updated: true } })
+    channel.port2.postMessage({ type: Message.INTERCEPTOR_UPDATE, operationId: 'interceptor-update', metadata: { updated: true } })
     await once(channel.port2, 'message')
-    channel.port2.postMessage({ type: Message.INTERCEPTOR_LEAVE })
+    channel.port2.postMessage({ type: Message.INTERCEPTOR_LEAVE, operationId: 'interceptor-leave' })
     await sleep(20)
 
     deepStrictEqual(coordinator.getMesh().interceptors, {})
@@ -626,6 +634,37 @@ test('coordinator accepts interceptor updates and ignores invalid worker message
   } finally {
     coordinator.destroy()
   }
+})
+
+test('coordinator rejects mesh mutations without operation IDs', async t => {
+  const id = directMeshId('missing-operation-id')
+  const errors: string[] = []
+  const coordinator = createCoordinator({ meshId: id, onError: error => errors.push(error.message) })
+  t.after(() => coordinator.destroy())
+
+  const channel = new MessageChannel()
+  coordinator.connectMember({
+    type: Message.COORDINATOR_CONNECT,
+    operationId: 'server-connect',
+    meshId: id,
+    role: 'server',
+    threadId,
+    port: channel.port1,
+    server: {
+      id: 'server-1',
+      origin: 'http:missing-operation.local',
+      state: 'available',
+      mode: 'thread'
+    }
+  })
+  await once(channel.port2, 'message')
+
+  channel.port2.postMessage({ type: Message.SERVER_UPDATE, state: 'paused' })
+  await sleep(10)
+
+  strictEqual(coordinator.getMesh().servers['server-1'].state, 'available')
+  deepStrictEqual(errors, ['Server update requires an operationId.'])
+  channel.port2.close()
 })
 
 test('coordinator rejects duplicate mesh ids and destroyed restarts', () => {
@@ -659,6 +698,7 @@ test('coordinator close is idempotent and rejects new members while closed', asy
   coordinator.close()
   coordinator.connectMember({
     type: Message.COORDINATOR_CONNECT,
+    operationId: 'closed-connect',
     meshId: id,
     role: 'server',
     threadId,
@@ -683,6 +723,7 @@ test('coordinator closes inconsistent connect messages', () => {
     let serverReads = 0
     const inconsistentServer = {
       type: Message.COORDINATOR_CONNECT,
+      operationId: 'inconsistent-server-connect',
       meshId: id,
       role: 'server',
       threadId,
@@ -699,6 +740,7 @@ test('coordinator closes inconsistent connect messages', () => {
     let interceptorReads = 0
     const inconsistentInterceptor = {
       type: Message.COORDINATOR_CONNECT,
+      operationId: 'inconsistent-interceptor-connect',
       meshId: id,
       role: 'interceptor',
       threadId,
@@ -766,4 +808,60 @@ test('server ignores redundant resume and updates metadata', async t => {
   await sleep(20)
   strictEqual(coordinator.getMesh().servers['server-1'].state, 'available')
   deepStrictEqual(coordinator.getMesh().servers['server-1'].metadata, { updated: true })
+})
+
+test('server readiness waits for interceptor mesh acknowledgement', async t => {
+  const id = directMeshId('ready-ack')
+  const coordinator = createCoordinator({ meshId: id })
+  t.after(() => coordinator.destroy())
+
+  const channel = new MessageChannel()
+  const received: Array<{ type?: string; operationId?: string }> = []
+  channel.port2.on('message', message => {
+    received.push(message as { type?: string; operationId?: string })
+  })
+  channel.port2.start()
+  coordinator.connectMember({
+    type: Message.COORDINATOR_CONNECT,
+    operationId: 'interceptor-join',
+    meshId: id,
+    role: 'interceptor',
+    threadId,
+    port: channel.port1,
+    interceptor: { id: 'interceptor-1' }
+  })
+
+  await sleep(10)
+  const initial = received.find(message => message.type === Message.MESH)
+  ok(initial?.operationId)
+  channel.port2.postMessage({ type: Message.MESH_ACK, operationId: initial.operationId })
+
+  const server = createServer({
+    meshId: id,
+    serverId: 'server-1',
+    domain: 'ready-ack.local',
+    server (_req: any, res: any) {
+      res.end('ok')
+    }
+  })
+  t.after(() => server.close())
+
+  let applied = false
+  server.ready.then(() => {
+    applied = true
+  })
+
+  for (let i = 0; i < 50 && received.length < 2; i++) {
+    await sleep(1)
+  }
+
+  strictEqual(applied, false)
+  for (const message of received) {
+    if (message.type === Message.MESH && message.operationId) {
+      channel.port2.postMessage({ type: Message.MESH_ACK, operationId: message.operationId })
+    }
+  }
+  await server.ready
+  strictEqual(applied, true)
+  channel.port2.close()
 })

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -6,7 +6,7 @@ import { MessageChannel, threadId, type MessagePort } from 'node:worker_threads'
 import Fastify from 'fastify'
 import { Agent, request } from 'undici'
 
-import { Coordinator, createCoordinator, createInterceptor, createServer } from '../src/index.ts'
+import { Coordinator, createCoordinator, createInterceptor, createServer, TargetChangedError } from '../src/index.ts'
 import { Message, type CoordinatorConnectMessage, type State } from '../src/protocol.ts'
 import {
   createAgent,
@@ -665,6 +665,11 @@ test('coordinator rejects mesh mutations without operation IDs', async t => {
   strictEqual(coordinator.getMesh().servers['server-1'].state, 'available')
   deepStrictEqual(errors, [{ message: 'Server update requires an operationId.', code: 'UND_TI_OPERATION_ID_REQUIRED' }])
   channel.port2.close()
+})
+
+test('target changed errors expose a stable code', () => {
+  const error = new TargetChangedError()
+  strictEqual(error.code, 'UND_TI_TARGET_CHANGED')
 })
 
 test('coordinator rejects duplicate mesh ids and destroyed restarts', () => {

--- a/test/resilience.test.ts
+++ b/test/resilience.test.ts
@@ -392,6 +392,7 @@ test('interceptor ignores peer messages without matching pending requests', asyn
   const serverChannel = new MessageChannel()
   coordinator.connectMember({
     type: Message.COORDINATOR_CONNECT,
+    operationId: 'server-connect',
     meshId,
     role: 'server',
     threadId,
@@ -572,6 +573,7 @@ test('closes orphaned response body ports so the sender can release buffered dat
   const serverChannel = new MessageChannel()
   coordinator.connectMember({
     type: Message.COORDINATOR_CONNECT,
+    operationId: 'orphaned-server-connect',
     meshId,
     role: 'server',
     threadId,


### PR DESCRIPTION
## Summary

- Added operation IDs to mesh mutations.
- Added per-operation mesh acknowledgement tracking.
- Made lifecycle promises resolve after mesh convergence.
- Deferred server draining until leave propagation completes.
- Revalidated stale targets before dispatch and transfer.
- Rejected mutations missing operation IDs.
- Added lifecycle and protocol validation tests.
- Updated lifecycle and protocol documentation.

## Testing

- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- 148 tests passed

Assisted-By: OpenAI:GPT-5.6 <openai/gpt-5.6>